### PR TITLE
Fix for PHP 8 and required/optional parameter order

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1336,7 +1336,7 @@ function cms_tpv_parse_query($q) {
  * Output JSON for the children of a node
  * $arrOpenChilds = array with id of pages to open children on
  */
-function cms_tpv_print_childs($pageID, $view = "all", $arrOpenChilds = null, $post_type) {
+function cms_tpv_print_childs($pageID, $view = "all", $arrOpenChilds = null, $post_type = "") {
 
 	$arrPages = cms_tpv_get_pages("parent=$pageID&view=$view&post_type=$post_type");
 


### PR DESCRIPTION
In PHP 8, required parameters that follow optional parameters has been deprecated. Currenting this code is issuing the warning:

 > Required parameter $post_type follows optional parameter $view

I checked all calls to this, and they all pass all four parameters, so we could actually remove the default values, however this change seems the simplest.